### PR TITLE
Load translations v2

### DIFF
--- a/parler/managers.py
+++ b/parler/managers.py
@@ -48,16 +48,6 @@ class TranslatableQuerySet(QuerySet):
         for field in instance._parler_meta.get_all_fields():
             getattr(instance, field)
 
-    def _chain(self, **kwargs):
-        """
-        Return a copy of the current QuerySet that's ready for another
-        operation.
-        """
-        objs = super()._chain()
-        for obj in objs:
-            self.load_translations(obj)
-        return objs
-
     def _fetch_all(self):
         # Make sure the current language is assigned when Django fetches the data.
         # This low-level method is overwritten as that works better across Django versions.
@@ -65,6 +55,7 @@ class TranslatableQuerySet(QuerySet):
         super()._fetch_all()
         if self._language is not None and self._result_cache and isinstance(self._result_cache[0], models.Model):
             for obj in self._result_cache:
+                self.load_translations(obj)
                 obj.set_current_language(self._language)
 
     def _extract_model_params(self, defaults, **kwargs):


### PR DESCRIPTION
Lucas había detectado este problema que había dejado comentado:

>Con django-hvad las traducciones que obteníamos estaban ligadas al tenant sobre el cuál obteníamos el contenido.
Con django-parler esto no funciona igual.
Lo que estaba ocurriendo era que si nosotros obtenemos alguna instancia en algún tenant, pero al momento de leer algún campo traducido estabamos sobre sobre otro, se buscaban las traducciones sobre este último tenant.
Esta función lee los campos traducibles de alguna instancia para no cargarlos de manera lazy.
La idea es utilizarla donde encontremos que sea necesario cargar las traducciones para luego leerlas.
Es importante no cachear los resultados de django-parler para que esto funcione bien.


Para solucionar este problema, creó la función `load_translations()` que lo solucionó pero tiene el inconveniente de que hay que incluirla en los lugares necesarios y esto se complica por los siguientes motivos:
- No es fácil de buscar/detectar lugares donde no se este usando y se deba usar.
- Es fácil de olvidarse de colocarla cuando se desarrolla nuevo código.


Ahora como usamos este fork, podemos aplicar la solución directamente en el código de parler y no tener que usar la función en el código de Smartfense.


### Ejemplo para reproducir el issue:

#### Usando language()

```python
from lms.utils import schema_context
from trainingcustom.models import TrainingCustom

with schema_context("schema_name"):
    training = TrainingCustom.objects.language("en-us").last()

print(training.name)
```

#### Usando translaed()

```python
from lms.utils import schema_context
from trainingcustom.models import TrainingCustom

with schema_context("schema_name"):
    training = TrainingCustom.objects.translated("en-us").last()

print(training.name)
```

Se puede probar que se soluciona llamando al atributo antes de salir del tenant o usando `load_translations()` (que justamente hace eso, iterar sobre cada campo traducible y llamarlo).


```python
from lms.utils import schema_context
from trainingcustom.models import TrainingCustom
from translations.import load_translations

with schema_context("schema_name"):
    training = TrainingCustom.objects.language("en-us").last()
    load_translations(training)

print(training.name)

with schema_context("schema_name"):
    training = TrainingCustom.objects.translated("en-us").last()
    load_translations(training)

print(training.name)

```

Con esta solución del fork no hace mas falta usar `load_tanslations()` en nuestro codigo cuando se usa .language(), si cuando se usa translated() (se usa en muchos menos lugares).

Probando con el primer ejemplo de codigo funciona bien.

